### PR TITLE
Handle memory underflow

### DIFF
--- a/Sources/Error/InterpretationError.swift
+++ b/Sources/Error/InterpretationError.swift
@@ -1,0 +1,21 @@
+//
+//  InterpretationError.swift
+//  
+//
+//  Created by Dominik Grodl on 13.02.2024.
+//
+
+import Foundation
+
+enum InterpretationError: Error {
+    case memoryUnderflow
+}
+
+extension InterpretationError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .memoryUnderflow:
+            return "Memory underflow. This means the memory pointer was pointing to the beginning of the memory, but current operation tried to move it to the left."
+        }
+    }
+}

--- a/Sources/Error/ParsingError.swift
+++ b/Sources/Error/ParsingError.swift
@@ -1,25 +1,11 @@
 //
-//  Error.swift
+//  ParsingError.swift
 //
 //
 //  Created by Dominik Grodl on 08.02.2024.
 //
 
 import Foundation
-
-enum ValidationError: Error {
-    case noProgramProvided
-    case noInputPathProvided
-    case unsuportedFileType(String)
-}
-
-enum InterpretationError: Error {
-    case memoryUnderflow
-}
-
-enum RuntimeError: Error {
-    case invalidInput
-}
 
 enum ParsingError: Error {
     case noCorrespondingJumpAddress(_ token: UInt8, _ index: Int)
@@ -36,3 +22,7 @@ extension ParsingError: LocalizedError {
         }
     }
 }
+
+
+
+

--- a/Sources/Error/ParsingError.swift
+++ b/Sources/Error/ParsingError.swift
@@ -1,25 +1,11 @@
 //
-//  Error.swift
+//  ParsingError.swift
 //
 //
 //  Created by Dominik Grodl on 08.02.2024.
 //
 
 import Foundation
-
-enum ValidationError: Error {
-    case noProgramProvided
-    case noInputPathProvided
-    case unsuportedFileType(String)
-}
-
-enum InterpretationError: Error {
-    case memoryUnderflow
-}
-
-enum RuntimeError: Error {
-    case invalidInput
-}
 
 enum ParsingError: Error {
     case noCorrespondingJumpAddress(_ token: Character, _ index: Int)
@@ -36,3 +22,7 @@ extension ParsingError: LocalizedError {
         }
     }
 }
+
+
+
+

--- a/Sources/Error/RuntimeError.swift
+++ b/Sources/Error/RuntimeError.swift
@@ -1,0 +1,11 @@
+//
+//  RuntimeError.swift
+//  
+//
+//  Created by Dominik Grodl on 13.02.2024.
+//
+
+enum RuntimeError: Error {
+    case invalidInput
+}
+

--- a/Sources/Error/ValidationError.swift
+++ b/Sources/Error/ValidationError.swift
@@ -1,0 +1,12 @@
+//
+//  ValidationError.swift
+//
+//
+//  Created by Dominik Grodl on 13.02.2024.
+//
+
+enum ValidationError: Error {
+    case noProgramProvided
+    case noInputPathProvided
+    case unsuportedFileType(String)
+}

--- a/Sources/Interpreter.swift
+++ b/Sources/Interpreter.swift
@@ -37,6 +37,10 @@ struct Interpreter {
                 
                 //move to previous slot, creating new memory slots if needed
             case .left:
+                guard memoryPointer > 0 else {
+                    throw InterpretationError.memoryUnderflow
+                }
+                
                 memoryPointer -= 1
                 operationsPointer += 1
                 


### PR DESCRIPTION
Handle a case when memory pointer is pointing to the beginning of memory but encountered operation tries to move it further left.

**Additions over original scope:**
- Add description to InterpretationError
- Move different errors to standalone files