### PR TITLE
Add parsing performance measure mode

### DIFF
--- a/Sources/BrainSwift.swift
+++ b/Sources/BrainSwift.swift
@@ -11,13 +11,33 @@ import ArgumentParser
 @main
 struct BrainSwift: ParsableCommand {
     @Argument var inputFile: String
+    @Option var runInParsingPerfMeasureModeWithCount: Int? = nil
     @Flag var outputMemory = false
     @Flag var outputIntermediateRepresentation = false
     
     func run() throws {
         let url = try validateInputReturnPath()
         let data = try extractProgramCode(url)
-        let representation = try Parser.parseIntermediateRepresentation(from: data)
+        
+        if let count = runInParsingPerfMeasureModeWithCount {
+            try runInParsingPerformanceMeasureMode(input: data, count: count)
+        } else {
+            try runInDefaulMode(input: data)
+        }
+    }
+    
+    func runInParsingPerformanceMeasureMode(input: Data, count: Int) throws {
+        let start = Date()
+        for _ in 0..<count {
+            let _ = try Parser.parseIntermediateRepresentation(from: input)
+        }
+        let resultTime = Date().timeIntervalSince(start)
+        print("Took:", resultTime, "seconds", separator: " ")
+        print("Average", resultTime / Double(count), "seconds", separator: " ")
+    }
+    
+    func runInDefaulMode(input: Data) throws {
+        let representation = try Parser.parseIntermediateRepresentation(from: input)
         
         if outputIntermediateRepresentation {
             Output.outputIntermediateRepresentation(representation)


### PR DESCRIPTION
This PR introduces the runInParsingPerfMeasureModeWithCount option, which allows to run the code parsing in measure mode to measure the performance.